### PR TITLE
(!Draft!) Add __vulns.json schema and valid example

### DIFF
--- a/vulns-json/example/__vulns.json
+++ b/vulns-json/example/__vulns.json
@@ -1,0 +1,258 @@
+{
+  "application": "juice-shop",
+  "vulnerabilities": [
+    {
+      "type": "xss",
+      "flags": [
+        "/#/search",
+        "q="
+      ]
+    },
+    {
+      "type": "sqli",
+      "flags": [
+        "/#/search",
+        "q="
+      ]
+    },
+    {
+      "type": "sqli",
+      "flags": [
+        "/#/login",
+        "email"
+      ]
+    },
+    {
+      "type": "sqli",
+      "flags": [
+        "/#/login",
+        "password"
+      ]
+    },
+    {
+      "type": "crypto",
+      "flags": [
+        "/ftp/eastere\\.gg",
+        "base64"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/#/administration"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/#/score-board"
+      ]
+    },
+    {
+      "type": "hash",
+      "flags": [
+        "/api/Users",
+        "md5"
+      ]
+    },
+    {
+      "type": "hash",
+      "flags": [
+        "/api/Users/[0-9]*",
+        "md5"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/api/Feedbacks/[0-9]*",
+        "delete"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/api/BasketItems/[0-9]*",
+        "put",
+        "quantity"
+      ]
+    },
+    {
+      "type": "session",
+      "flags": [
+        "sessionStorage",
+        "bid"
+      ]
+    },
+    {
+      "type": "csrf",
+      "flags": [
+        "/rest/user/change-password",
+        "get"
+      ]
+    },
+    {
+      "type": "trustbound",
+      "flags": [
+        "/rest/user/change-password.*^((?!current).)*$",
+        "new",
+        "repeat"
+      ]
+    },
+    {
+      "type": "trustbound",
+      "flags": [
+        "/#/complain",
+        "/file-upload",
+        "size"
+      ]
+    },
+    {
+      "type": "trustbound",
+      "flags": [
+        "/#/complain",
+        "/file-upload",
+        "type"
+      ]
+    },
+    {
+      "type": "session",
+      "flags": [
+        "/#/contact",
+        "userId",
+        "hide"
+      ]
+    },
+    {
+      "type": "xss",
+      "flags": [
+        "/#/contact",
+        "comment"
+      ]
+    },
+    {
+      "type": "crypto",
+      "flags": [
+        "/#/basket",
+        "coupon",
+        "(z85|base85)"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/the/devs/are/so/funny/they/hid/an/easter/egg/within/the/easter/egg"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "css/geo-bootstrap/swatch/bootstrap\\.css"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/i18n/tlh\\.json"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/ftp/.*%2500\\.md"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/ftp/.*%2500\\.pdf"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/ftp/.*?md_debug=.*\\.pdf"
+      ]
+    },
+    {
+      "type": "access",
+      "flags": [
+        "/ftp/.*?md_debug=.*\\.md"
+      ]
+    },
+    {
+      "type": "redirect",
+      "flags": [
+        "/redirect?to=.*?.*=https://github.com/bkimminich/juice-shop"
+      ]
+    },
+    {
+      "type": "redirect",
+      "flags": [
+        "/redirect?to=.*?.*=https://blockchain.info/address/1FXJq5yVANLzR6ZWfqPKhJU3zWT3apnxmN"
+      ]
+    },
+    {
+      "type": "redirect",
+      "flags": [
+        "/redirect?to=.*?.*=https://gratipay.com/juice-shop"
+      ]
+    },
+    {
+      "type": "redirect",
+      "flags": [
+        "/redirect?to=.*?.*=http://flattr.com/thing/3856930/bkimminichjuice-shop-on-GitHub"
+      ]
+    },
+    {
+      "type": "xss",
+      "flags": [
+        "/#/administration",
+        "post",
+        "/api/Users",
+        "email"
+      ]
+    },
+    {
+      "type": "xss",
+      "flags": [
+        "/#/search",
+        "post",
+        "/api/Products",
+        "description"
+      ]
+    },
+    {
+      "type": "xss",
+      "flags": [
+        "/#/search",
+        "put",
+        "/api/Products/[0-9]*",
+        "description"
+      ]
+    },
+    {
+      "type": "crypto",
+      "flags": [
+        "/#/score-board",
+        "continueCode",
+        "hashid"
+      ]
+    },
+    {
+      "type": "leakage",
+      "flags": [
+        "/#/login",
+        "{\"error\":{\"message\":\"SQLITE_ERROR"
+      ]
+    },
+    {
+      "type": "leakage",
+      "flags": [
+        "Juice Shop (Express ~",
+        "Error:",
+        "at app/routes"
+      ]
+    }
+  ]
+}

--- a/vulns-json/schema.json
+++ b/vulns-json/schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Vulnerability matchers for an intentionally vulnerable web application",
+    "type": "object",
+    "properties": {
+        "application": { "description": "The unique name of the vulnerable web application", "type": "string" },
+        "vulnerabilities": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type" : { "enum": [ "xss", "sqli", "crypto", "access", "hash", "session", "csrf", "trustbound", "redirect", "leakage" ] },
+                        "flags": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          },
+                          "minItems": 1,
+                          "uniqueItems": true
+                        }
+                    },
+                    "required": ["type", "flags"]
+                },
+                "uniqueItems": true
+            }
+    },
+    "required": ["application", "vulnerabilities"]
+}


### PR DESCRIPTION
A quick way to validate an own `__vulns.json` file against the schema:

1. clone the [OWASP-VWAD](https://github.com/OWASP/OWASP-VWAD) repository
2. install "Another JSON Schema Validator" via `npm install -g ajv-cli`
3. `cd` into the `vulns-json` folder of the cloned repository
4. _(optional)_ run `ajv -s schema -d example/__vulns.json` to confirm the example is valid
5. create your own `__vulns.json` and validate it via `ajv -s schema -d path/to/your/__vulns.json`