### PR TITLE
Add secDevLabs to the list of offline applications

### DIFF
--- a/src/data/offline.json
+++ b/src/data/offline.json
@@ -752,7 +752,7 @@
 			}
 		],
 		"author": "Globo",
-		"notes": "Repository with many intentionally vulnerable web applications. Includes attack naratives and docker options for each app.",
+		"notes": "Repository with many intentionally vulnerable web applications. Includes attack narratives and docker options for each app.",
 		"badge": "globocom/secDevLabs"
 	},
 	{

--- a/src/data/offline.json
+++ b/src/data/offline.json
@@ -734,6 +734,28 @@
 		"badge": "OWASP/railsgoat"
 	},
 	{
+		"url": "https://github.com/globocom/secDevLabs",
+		"name": "SecDevLabs",
+		"technology": [
+			"Go",
+			"NodeJS",
+			"Python",
+			"PHP",
+			"React",
+			"Angular/Spring",
+			"Dart/Flutter"
+		],
+		"references": [
+			{
+				"name": "guide",
+				"url": "https://github.com/globocom/secDevLabs"
+			}
+		],
+		"author": "Globo",
+		"notes": "Repository with many intentionally vulnerable web applications. Includes attack naratives and docker options for each app.",
+		"badge": "globocom/secDevLabs"
+	},
+	{
 		"url": "https://github.com/sqlmapproject/testenv",
 		"name": "SQL injection test environment",
 		"technology": [


### PR DESCRIPTION
The goal of this PR is to add [secDevLabs](https://github.com/globocom/secDevLabs) to the list of offline applications.