### PR TITLE
chore: www publishing workflow now uses a static feature branch name

### DIFF
--- a/.github/workflows/create_www_update.yml
+++ b/.github/workflows/create_www_update.yml
@@ -28,12 +28,12 @@ jobs:
         VWAD_BASE="$(pwd)"
         # Setup env vars for later
         SRC_BASE="OWASP/OWASP-VWAD@"$(git log -1 --format=format:%h)
-        BRANCH_STAMP="$(date +"%Y%m%d%H%M%S")"
+        BRANCH="vwad-update"
         SHORT_DATE="$(date +"%Y-%m-%d")"
         export GITHUB_TOKEN=${{ secrets.vwad_deploy_token }}
         # Build the feature branch
         cd $WWW_BASE
-        git checkout -b $BRANCH_STAMP
+        git checkout -b $BRANCH
         rm _data/offline.json
         rm _data/online.json
         rm _data/vm-iso.json
@@ -45,6 +45,6 @@ jobs:
         git remote set-url origin https://$GITHUB_USER:${{ secrets.vwad_deploy_token }}@github.com/$GITHUB_USER/www-project-vulnerable-web-applications-directory.git
         git add .
         git commit -m "VWAD Update $SHORT_DATE" -m "Updates based on $SRC_BASE"
-        git push --set-upstream origin $BRANCH_STAMP
+        git push --set-upstream origin $BRANCH --force
         # Open the PR
         hub pull-request --no-edit


### PR DESCRIPTION
Use a static feature branch name vs. datestamp so that vwadbot doesn't endup with a ton of branches (or hitting some GitHub limit).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>