### PR TITLE
Remove EnigmaGroup

### DIFF
--- a/src/data/collection.json
+++ b/src/data/collection.json
@@ -626,18 +626,6 @@
 		"badge": "k-tamura/easybuggy"
 	},
 	{
-		"url": "http://enigmagroup.org/",
-		"name": "Enigma Group",
-		"collection": [
-			"online"
-		],
-		"technology": [],
-		"references": [],
-		"author": "Enigma Group",
-		"notes": null,
-		"badge": null
-	},
-	{
 		"url": "http://sourceforge.net/projects/exploitcoilvuln/files/",
 		"name": "Exploit.co.il Vuln Web App",
 		"collection": [


### PR DESCRIPTION
Sometime in 2021/early 2022 the live training/CTF went away.
https://web.archive.org/web/20220501000000*/https://enigmagroup.org/

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>