### PR TITLE
Damn Vulnerable Application Scanner (DVAS)

### DIFF
--- a/src/data/collection.json
+++ b/src/data/collection.json
@@ -410,9 +410,18 @@
 		"technology": [
 			"PHP"
 		],
-		"references": [],
+		"references": [
+        {
+            "name": "paper",
+            "url": "https://ceur-ws.org/Vol-2940/paper36.pdf"
+        },
+        {
+            "name": "announcement",
+            "url": "https://avalz.it/research/metasploit-pro-xss-to-rce/"
+        }
+    ],
 		"author": "Andrea Valenza, Enrico Russo, Gabriele Costa",
-		"notes": null,
+		"notes": "HTTP Response fuzzer to find Vulnerabilities in Security Scanners",
 		"badge": "AvalZ/DVAS"
 	},
 	{

--- a/src/data/collection.json
+++ b/src/data/collection.json
@@ -412,7 +412,7 @@
 		],
 		"references": [
         {
-            "name": "paper",
+            "name": "guide",
             "url": "https://ceur-ws.org/Vol-2940/paper36.pdf"
         },
         {

--- a/src/data/collection.json
+++ b/src/data/collection.json
@@ -421,7 +421,7 @@
         }
     ],
 		"author": "Andrea Valenza, Enrico Russo, Gabriele Costa",
-		"notes": "HTTP Response fuzzer to find Vulnerabilities in Security Scanners",
+		"notes": "An intentionally vulnerable web application scanner",
 		"badge": "AvalZ/DVAS"
 	},
 	{

--- a/src/data/collection.json
+++ b/src/data/collection.json
@@ -402,6 +402,20 @@
 		"badge": "stamparm/DSVW"
 	},
 	{
+		"url": "https://github.com/AvalZ/DVAS",
+		"name": "Damn Vulnerable Application Scanner (DVAS)",
+		"collection": [
+			"offline"
+		],
+		"technology": [
+			"PHP"
+		],
+		"references": [],
+		"author": "Andrea Valenza, Enrico Russo, Gabriele Costa",
+		"notes": null,
+		"badge": "AvalZ/DVAS"
+	},
+	{
 		"url": "https://github.com/rewanthtammana/Damn-Vulnerable-Bank",
 		"name": "Damn Vulnerable Bank",
 		"collection": [


### PR DESCRIPTION
DVAS contains a collection of web-based (vulnerable) security scanners, including (but not limited to) the vulnerabilities from ["Never Trust Your Victim: Weaponizing Vulnerabilities in Security Scanners"](https://www.researchgate.net/publication/344642774_Never_Trust_Your_Victim_Weaponizing_Vulnerabilities_in_Security_Scanners). DVAS also contains a simulation of [CVE-2020-7354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-7354) and [CVE-2020-7355](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-7355) for Metasploit Pro.